### PR TITLE
Fix workflow to execute release job properly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,15 @@ workflows:
           filters:
             branches:
               only: '/.*/'
+            tags:
+              only: '/.*'
       - lint:
           requires:
             - 'prepare'
           filters:
             branches:
+              only: '/.*/'
+            tags:
               only: '/.*/'
       - build:
           requires:
@@ -89,11 +93,15 @@ workflows:
           filters:
             branches:
               only: '/.*/'
+            tags:
+              only: '/.*/'
       - test:
           requires:
             - 'build'
           filters:
             branches:
+              only: '/.*/'
+            tags:
               only: '/.*/'
       - release:
           requires:


### PR DESCRIPTION
The `release` job is not invoked with current CircleCI config. I hope
that this change solves the problem.